### PR TITLE
Fix get_error parameter order and slide style bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -782,7 +782,7 @@ async fn get_error(
     path: web::Path<(String, String)>,
     state: web::Data<Addr<State>>,
 ) -> impl Responder {
-    let (name, code) = path.into_inner();
+    let (code, name) = path.into_inner();
     if name.is_inappropriate() {
         return ugg("Name is inappropriate");
     }

--- a/static/teacher.html
+++ b/static/teacher.html
@@ -121,7 +121,7 @@
                     let style = slide.TitleText[2];
                     playingGame.innerHTML = "<div id=\"slide\" style='background-color: " + style.color + "; color: " + style.font_color + "'><h1 class='slideTitle'>" + slide.TitleText[0] + "</h1><p>" + slide.TitleText[1] + "</p><button onclick='continue5Secs()'>Continue</button></div>";
                 } else if (slide.OnlyText) {
-                    let style = slide.TitleText[2];
+                    let style = slide.OnlyText[1];
                     playingGame.innerHTML = "<div id=\"slide\" style='background-color: " + style.color + "; color: " + style.font_color + "'><p>" + slide.OnlyText[0] + "</p><button onclick='continue5Secs()'>Continue</button></div>";
                 }
             }


### PR DESCRIPTION
## Summary
- fix swapped `code`/`name` parameters in `get_error`
- use proper style index for `OnlyText` slides

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68407f62e30c8324a74a8cc4e6b6be66